### PR TITLE
Restore OG metadata to use app name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-APP_NAME="Pixelfed"
-APP_OG_TITLE="Pixelfed"
+APP_NAME="P1000"
+APP_OG_TITLE="P1000"
 APP_ENV="production"
 APP_KEY=
 APP_DEBUG="false"

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 APP_NAME="Pixelfed"
+APP_OG_TITLE="Pixelfed"
 APP_ENV="production"
 APP_KEY=
 APP_DEBUG="false"

--- a/app/Services/ConfigCacheService.php
+++ b/app/Services/ConfigCacheService.php
@@ -31,6 +31,7 @@ class ConfigCacheService
             return Cache::remember($cacheKey, $ttl, function () use ($key) {
                 $allowed = [
                     'app.name',
+                    'app.og_title',
                     'app.short_description',
                     'app.description',
                     'app.rules',

--- a/config/app.php
+++ b/config/app.php
@@ -13,8 +13,8 @@ return [
     |
     */
 
-    'name' => env('APP_NAME', 'Pixelfed'),
-    'og_title' => env('APP_OG_TITLE', env('APP_NAME', 'Pixelfed')),
+    'name' => env('APP_NAME', 'P1000'),
+    'og_title' => env('APP_OG_TITLE', env('APP_NAME', 'P1000')),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -14,6 +14,7 @@ return [
     */
 
     'name' => env('APP_NAME', 'Pixelfed'),
+    'og_title' => env('APP_OG_TITLE', env('APP_NAME', 'Pixelfed')),
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -12,7 +12,7 @@
 	<link rel="manifest" href="/manifest.json">
 
 	<meta property="og:site_name" content="{{ config_cache('app.name') }}">
-	<meta property="og:title" content="{{ $title ?? config_cache('app.name') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -12,7 +12,7 @@
 	<link rel="manifest" href="/manifest.json">
 
 	<meta property="og:site_name" content="{{ config_cache('app.name') }}">
-        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -12,7 +12,7 @@
 	<link rel="manifest" href="/manifest.json">
 
 	<meta property="og:site_name" content="{{ config_cache('app.name') }}">
-        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')

--- a/resources/views/layouts/anon.blade.php
+++ b/resources/views/layouts/anon.blade.php
@@ -12,7 +12,7 @@
     <title>{{ $title ?? config_cache('app.name') }}</title>
 
     @if(isset($title))<meta property="og:site_name" content="{{ config_cache('app.name') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.name') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
     <meta property="og:type" content="article">
     <meta property="og:url" content="{{request()->url()}}">
     @endif

--- a/resources/views/layouts/anon.blade.php
+++ b/resources/views/layouts/anon.blade.php
@@ -12,7 +12,7 @@
     <title>{{ $title ?? config_cache('app.name') }}</title>
 
     @if(isset($title))<meta property="og:site_name" content="{{ config_cache('app.name') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
     <meta property="og:type" content="article">
     <meta property="og:url" content="{{request()->url()}}">
     @endif

--- a/resources/views/layouts/anon.blade.php
+++ b/resources/views/layouts/anon.blade.php
@@ -12,7 +12,7 @@
     <title>{{ $title ?? config_cache('app.name') }}</title>
 
     @if(isset($title))<meta property="og:site_name" content="{{ config_cache('app.name') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
     <meta property="og:type" content="article">
     <meta property="og:url" content="{{request()->url()}}">
     @endif

--- a/resources/views/layouts/app-guest.blade.php
+++ b/resources/views/layouts/app-guest.blade.php
@@ -9,7 +9,7 @@
 	<link rel="manifest" href="{{url('/manifest.json')}}">
 
 	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')

--- a/resources/views/layouts/app-guest.blade.php
+++ b/resources/views/layouts/app-guest.blade.php
@@ -9,7 +9,7 @@
 	<link rel="manifest" href="{{url('/manifest.json')}}">
 
 	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-	<meta property="og:title" content="{{ $title ?? config_cache('app.name', 'pixelfed') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')

--- a/resources/views/layouts/app-guest.blade.php
+++ b/resources/views/layouts/app-guest.blade.php
@@ -5,11 +5,11 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 	<meta name="mobile-web-app-capable" content="yes">
 
-	<title>{{ $title ?? config_cache('app.name', 'Pixelfed') }}</title>
+	<title>{{ $title ?? config_cache('app.name', 'P1000') }}</title>
 	<link rel="manifest" href="{{url('/manifest.json')}}">
 
-	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+	<meta property="og:site_name" content="{{ config_cache('app.name', 'P1000') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,7 +13,7 @@
 	<link rel="manifest" href="{{url('/manifest.json')}}">
 	<meta property="og:logo" content="{{ url('/img/pixelfed-icon-color.png')}}" />
         <meta property="og:site_name" content="{{ config_cache('app.name', 'Pixelfed') }}">
-	<meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.name') }}">
+        <meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.og_title') }}">
 	<meta property="og:type" content="{{ $ogType ?? 'article' }}">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')
@@ -74,7 +74,7 @@
 	<link rel="manifest" href="/manifest.json">
 	<meta property="og:logo" content="{{ url('/img/pixelfed-icon-color.png')}}" />
         <meta property="og:site_name" content="{{ config_cache('app.name', 'Pixelfed') }}">
-	<meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.name', 'pixelfed') }}">
+        <meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.og_title') }}">
 	<meta property="og:type" content="{{ $ogType ?? 'article' }}">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,7 +13,7 @@
 	<link rel="manifest" href="{{url('/manifest.json')}}">
 	<meta property="og:logo" content="{{ url('/img/pixelfed-icon-color.png')}}" />
         <meta property="og:site_name" content="{{ config_cache('app.name', 'Pixelfed') }}">
-        <meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.og_title') }}">
+        <meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
 	<meta property="og:type" content="{{ $ogType ?? 'article' }}">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')
@@ -74,7 +74,7 @@
 	<link rel="manifest" href="/manifest.json">
 	<meta property="og:logo" content="{{ url('/img/pixelfed-icon-color.png')}}" />
         <meta property="og:site_name" content="{{ config_cache('app.name', 'Pixelfed') }}">
-        <meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.og_title') }}">
+        <meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
 	<meta property="og:type" content="{{ $ogType ?? 'article' }}">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,7 +12,7 @@
 	<title>{{ $title ?? config_cache('app.name') }}</title>
 	<link rel="manifest" href="{{url('/manifest.json')}}">
 	<meta property="og:logo" content="{{ url('/img/pixelfed-icon-color.png')}}" />
-	<meta property="og:site_name" content="Pixelfed">
+        <meta property="og:site_name" content="{{ config_cache('app.name', 'Pixelfed') }}">
 	<meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.name') }}">
 	<meta property="og:type" content="{{ $ogType ?? 'article' }}">
 	<meta property="og:url" content="{{url(request()->url())}}">
@@ -73,7 +73,7 @@
 	<title>{{ $title ?? config_cache('app.name', 'Pixelfed') }}</title>
 	<link rel="manifest" href="/manifest.json">
 	<meta property="og:logo" content="{{ url('/img/pixelfed-icon-color.png')}}" />
-	<meta property="og:site_name" content="Pixelfed">
+        <meta property="og:site_name" content="{{ config_cache('app.name', 'Pixelfed') }}">
 	<meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.name', 'pixelfed') }}">
 	<meta property="og:type" content="{{ $ogType ?? 'article' }}">
 	<meta property="og:url" content="{{url(request()->url())}}">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,8 +12,8 @@
 	<title>{{ $title ?? config_cache('app.name') }}</title>
 	<link rel="manifest" href="{{url('/manifest.json')}}">
 	<meta property="og:logo" content="{{ url('/img/pixelfed-icon-color.png')}}" />
-        <meta property="og:site_name" content="{{ config_cache('app.name', 'Pixelfed') }}">
-        <meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+        <meta property="og:site_name" content="{{ config_cache('app.name', 'P1000') }}">
+        <meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
 	<meta property="og:type" content="{{ $ogType ?? 'article' }}">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')
@@ -70,11 +70,11 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 	<meta name="mobile-web-app-capable" content="yes">
 
-	<title>{{ $title ?? config_cache('app.name', 'Pixelfed') }}</title>
+	<title>{{ $title ?? config_cache('app.name', 'P1000') }}</title>
 	<link rel="manifest" href="/manifest.json">
 	<meta property="og:logo" content="{{ url('/img/pixelfed-icon-color.png')}}" />
-        <meta property="og:site_name" content="{{ config_cache('app.name', 'Pixelfed') }}">
-        <meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+        <meta property="og:site_name" content="{{ config_cache('app.name', 'P1000') }}">
+        <meta property="og:title" content="{{ $ogTitle ?? $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
 	<meta property="og:type" content="{{ $ogType ?? 'article' }}">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')

--- a/resources/views/layouts/blank.blade.php
+++ b/resources/views/layouts/blank.blade.php
@@ -12,7 +12,7 @@
 	<title>{{ $title ?? config_cache('app.name') }}</title>
 
 	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-	<meta property="og:title" content="{{ $title ?? config_cache('app.name', 'pixelfed') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{request()->url()}}">
 	@stack('meta')

--- a/resources/views/layouts/blank.blade.php
+++ b/resources/views/layouts/blank.blade.php
@@ -11,8 +11,8 @@
 
 	<title>{{ $title ?? config_cache('app.name') }}</title>
 
-	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+	<meta property="og:site_name" content="{{ config_cache('app.name', 'P1000') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{request()->url()}}">
 	@stack('meta')

--- a/resources/views/layouts/blank.blade.php
+++ b/resources/views/layouts/blank.blade.php
@@ -12,7 +12,7 @@
 	<title>{{ $title ?? config_cache('app.name') }}</title>
 
 	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{request()->url()}}">
 	@stack('meta')

--- a/resources/views/layouts/bundle.blade.php
+++ b/resources/views/layouts/bundle.blade.php
@@ -9,11 +9,11 @@
 
     <meta name="mobile-web-app-capable" content="yes">
 
-    <title>{{ $title ?? config_cache('app.name', 'Pixelfed') }}</title>
+    <title>{{ $title ?? config_cache('app.name', 'P1000') }}</title>
     <link rel="manifest" href="/manifest.json">
 
-    <meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+    <meta property="og:site_name" content="{{ config_cache('app.name', 'P1000') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
     <meta property="og:type" content="article">
     <meta property="og:url" content="{{request()->url()}}">
     @stack('meta')

--- a/resources/views/layouts/bundle.blade.php
+++ b/resources/views/layouts/bundle.blade.php
@@ -13,7 +13,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
     <meta property="og:type" content="article">
     <meta property="og:url" content="{{request()->url()}}">
     @stack('meta')

--- a/resources/views/layouts/bundle.blade.php
+++ b/resources/views/layouts/bundle.blade.php
@@ -13,7 +13,7 @@
     <link rel="manifest" href="/manifest.json">
 
     <meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.name', 'pixelfed') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
     <meta property="og:type" content="article">
     <meta property="og:url" content="{{request()->url()}}">
     @stack('meta')

--- a/resources/views/layouts/partial/noauthnav.blade.php
+++ b/resources/views/layouts/partial/noauthnav.blade.php
@@ -2,7 +2,7 @@
     <div class="container">
         <a class="navbar-brand d-flex align-items-center" href="{{ url('/') }}">
             <img src="/img/pixelfed-icon-color.svg" height="30px" class="px-2" alt="Pixelfed logo">
-            <span class="font-weight-bold mb-0" style="font-size:20px;">{{ config_cache('app.name', 'Pixelfed') }}</span>
+            <span class="font-weight-bold mb-0" style="font-size:20px;">{{ config_cache('app.name', 'P1000') }}</span>
         </a>
     </div>
 </nav>

--- a/resources/views/layouts/spa.blade.php
+++ b/resources/views/layouts/spa.blade.php
@@ -9,7 +9,7 @@
 	<title>{{ $title ?? config_cache('app.name') }}</title>
 	<link rel="manifest" href="{{url('/manifest.json')}}">
 	<meta property="og:site_name" content="{{ config_cache('app.name') }}">
-        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')

--- a/resources/views/layouts/spa.blade.php
+++ b/resources/views/layouts/spa.blade.php
@@ -9,7 +9,7 @@
 	<title>{{ $title ?? config_cache('app.name') }}</title>
 	<link rel="manifest" href="{{url('/manifest.json')}}">
 	<meta property="og:site_name" content="{{ config_cache('app.name') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')

--- a/resources/views/layouts/spa.blade.php
+++ b/resources/views/layouts/spa.blade.php
@@ -9,7 +9,7 @@
 	<title>{{ $title ?? config_cache('app.name') }}</title>
 	<link rel="manifest" href="{{url('/manifest.json')}}">
 	<meta property="og:site_name" content="{{ config_cache('app.name') }}">
-	<meta property="og:title" content="{{ $title ?? config_cache('app.name') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{url(request()->url())}}">
 	@stack('meta')

--- a/resources/views/portfolio/layout.blade.php
+++ b/resources/views/portfolio/layout.blade.php
@@ -12,7 +12,7 @@
 	<title>{!! $title ?? config_cache('app.name') !!}</title>
 
 	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-	<meta property="og:title" content="{{ $title ?? config_cache('app.name', 'pixelfed') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{request()->url()}}">
 	@stack('meta')

--- a/resources/views/portfolio/layout.blade.php
+++ b/resources/views/portfolio/layout.blade.php
@@ -12,7 +12,7 @@
 	<title>{!! $title ?? config_cache('app.name') !!}</title>
 
 	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{request()->url()}}">
 	@stack('meta')

--- a/resources/views/portfolio/layout.blade.php
+++ b/resources/views/portfolio/layout.blade.php
@@ -11,8 +11,8 @@
 
 	<title>{!! $title ?? config_cache('app.name') !!}</title>
 
-	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+	<meta property="og:site_name" content="{{ config_cache('app.name', 'P1000') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{request()->url()}}">
 	@stack('meta')

--- a/resources/views/profile/embed-removed.blade.php
+++ b/resources/views/profile/embed-removed.blade.php
@@ -9,8 +9,8 @@
 
 	<title>Pixelfed | 404 Embed Not Found</title>
 
-	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+	<meta property="og:site_name" content="{{ config_cache('app.name', 'P1000') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
 	<meta name="medium" content="image">
 	<meta name="theme-color" content="#10c5f8">
 	<meta name="apple-mobile-web-app-capable" content="yes">

--- a/resources/views/profile/embed-removed.blade.php
+++ b/resources/views/profile/embed-removed.blade.php
@@ -10,7 +10,7 @@
 	<title>Pixelfed | 404 Embed Not Found</title>
 
 	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
 	<meta name="medium" content="image">
 	<meta name="theme-color" content="#10c5f8">
 	<meta name="apple-mobile-web-app-capable" content="yes">

--- a/resources/views/profile/embed-removed.blade.php
+++ b/resources/views/profile/embed-removed.blade.php
@@ -10,7 +10,7 @@
 	<title>Pixelfed | 404 Embed Not Found</title>
 
 	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-	<meta property="og:title" content="{{ $title ?? config_cache('app.name', 'pixelfed') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
 	<meta name="medium" content="image">
 	<meta name="theme-color" content="#10c5f8">
 	<meta name="apple-mobile-web-app-capable" content="yes">

--- a/resources/views/profile/embed.blade.php
+++ b/resources/views/profile/embed.blade.php
@@ -7,7 +7,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <title>{{ $title ?? config_cache('app.name', 'Pixelfed') }}</title>
     <meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
     <meta property="og:type" content="profile">
     <meta property="og:url" content="{{$profile['url']}}">
     <meta name="medium" content="image">

--- a/resources/views/profile/embed.blade.php
+++ b/resources/views/profile/embed.blade.php
@@ -7,7 +7,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <title>{{ $title ?? config_cache('app.name', 'Pixelfed') }}</title>
     <meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.name', 'pixelfed') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
     <meta property="og:type" content="profile">
     <meta property="og:url" content="{{$profile['url']}}">
     <meta name="medium" content="image">

--- a/resources/views/profile/embed.blade.php
+++ b/resources/views/profile/embed.blade.php
@@ -5,9 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="mobile-web-app-capable" content="yes">
-    <title>{{ $title ?? config_cache('app.name', 'Pixelfed') }}</title>
-    <meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+    <title>{{ $title ?? config_cache('app.name', 'P1000') }}</title>
+    <meta property="og:site_name" content="{{ config_cache('app.name', 'P1000') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
     <meta property="og:type" content="profile">
     <meta property="og:url" content="{{$profile['url']}}">
     <meta name="medium" content="image">

--- a/resources/views/site/about.blade.php
+++ b/resources/views/site/about.blade.php
@@ -6,9 +6,9 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="mobile-web-app-capable" content="yes">
-	<title>{{ config_cache('app.name') ?? 'pixelfed' }}</title>
-	<meta property="og:site_name" content="{{ config_cache('app.name') ?? 'pixelfed' }}">
-        <meta property="og:title" content="{{ config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) ?? 'pixelfed' }}">
+        <title>{{ config_cache('app.name') ?? 'P1000' }}</title>
+        <meta property="og:site_name" content="{{ config_cache('app.name') ?? 'P1000' }}">
+        <meta property="og:title" content="{{ config_cache('app.og_title', config_cache('app.name', 'P1000')) ?? 'P1000' }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{route('site.about')}}">
 	<meta property="og:description" content="{{config_cache('app.short_description')}}">

--- a/resources/views/site/about.blade.php
+++ b/resources/views/site/about.blade.php
@@ -8,7 +8,7 @@
 	<meta name="mobile-web-app-capable" content="yes">
 	<title>{{ config_cache('app.name') ?? 'pixelfed' }}</title>
 	<meta property="og:site_name" content="{{ config_cache('app.name') ?? 'pixelfed' }}">
-	<meta property="og:title" content="{{ config_cache('app.name') ?? 'pixelfed' }}">
+        <meta property="og:title" content="{{ config_cache('app.og_title') ?? 'pixelfed' }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{route('site.about')}}">
 	<meta property="og:description" content="{{config_cache('app.short_description')}}">

--- a/resources/views/site/about.blade.php
+++ b/resources/views/site/about.blade.php
@@ -8,7 +8,7 @@
 	<meta name="mobile-web-app-capable" content="yes">
 	<title>{{ config_cache('app.name') ?? 'pixelfed' }}</title>
 	<meta property="og:site_name" content="{{ config_cache('app.name') ?? 'pixelfed' }}">
-        <meta property="og:title" content="{{ config_cache('app.og_title') ?? 'pixelfed' }}">
+        <meta property="og:title" content="{{ config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) ?? 'pixelfed' }}">
 	<meta property="og:type" content="article">
 	<meta property="og:url" content="{{route('site.about')}}">
 	<meta property="og:description" content="{{config_cache('app.short_description')}}">

--- a/resources/views/site/index.blade.php
+++ b/resources/views/site/index.blade.php
@@ -13,13 +13,13 @@
 	<link rel="canonical" href="{{ request()->url() }}" />
 
 	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}" />
-	<meta property="og:title" content="{{ config_cache('app.name', 'pixelfed') }}" />
+        <meta property="og:title" content="{{ config_cache('app.og_title') }}" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="{{request()->url()}}" />
 	<meta property="og:image" content="{{ config_cache('app.banner_image') ?? url('storage/headers/default.jpg')}}" />
 	<meta property="og:description" content="{{ config_cache('app.short_description') ?? 'Decentralized photo sharing social media powered by Pixelfed' }}" />
 	<meta name="description" content="{{ config_cache('app.short_description') ?? 'Decentralized photo sharing social media powered by Pixelfed' }}" />
-	<meta name="twitter:title" content="{{ config_cache('app.name', 'pixelfed') }}" />
+        <meta name="twitter:title" content="{{ config_cache('app.og_title') }}" />
     <meta name="twitter:description" content="{{ config_cache('app.short_description') ?? 'Decentralized photo sharing social media powered by Pixelfed' }}" />
     <meta name="twitter:image" content="{{ config_cache('app.banner_image') ?? url('storage/headers/default.jpg')}}" />
     <meta name="twitter:card" content="summary_large_image" />

--- a/resources/views/site/index.blade.php
+++ b/resources/views/site/index.blade.php
@@ -8,18 +8,18 @@
 
 	<meta name="mobile-web-app-capable" content="yes">
 
-	<title>{{ config_cache('app.name', 'Pixelfed') }}</title>
+	<title>{{ config_cache('app.name', 'P1000') }}</title>
 
 	<link rel="canonical" href="{{ request()->url() }}" />
 
-	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}" />
-        <meta property="og:title" content="{{ config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}" />
+	<meta property="og:site_name" content="{{ config_cache('app.name', 'P1000') }}" />
+        <meta property="og:title" content="{{ config_cache('app.og_title', config_cache('app.name', 'P1000')) }}" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="{{request()->url()}}" />
 	<meta property="og:image" content="{{ config_cache('app.banner_image') ?? url('storage/headers/default.jpg')}}" />
 	<meta property="og:description" content="{{ config_cache('app.short_description') ?? 'Decentralized photo sharing social media powered by Pixelfed' }}" />
 	<meta name="description" content="{{ config_cache('app.short_description') ?? 'Decentralized photo sharing social media powered by Pixelfed' }}" />
-        <meta name="twitter:title" content="{{ config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}" />
+        <meta name="twitter:title" content="{{ config_cache('app.og_title', config_cache('app.name', 'P1000')) }}" />
     <meta name="twitter:description" content="{{ config_cache('app.short_description') ?? 'Decentralized photo sharing social media powered by Pixelfed' }}" />
     <meta name="twitter:image" content="{{ config_cache('app.banner_image') ?? url('storage/headers/default.jpg')}}" />
     <meta name="twitter:card" content="summary_large_image" />

--- a/resources/views/site/index.blade.php
+++ b/resources/views/site/index.blade.php
@@ -13,13 +13,13 @@
 	<link rel="canonical" href="{{ request()->url() }}" />
 
 	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}" />
-        <meta property="og:title" content="{{ config_cache('app.og_title') }}" />
+        <meta property="og:title" content="{{ config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}" />
 	<meta property="og:type" content="website" />
 	<meta property="og:url" content="{{request()->url()}}" />
 	<meta property="og:image" content="{{ config_cache('app.banner_image') ?? url('storage/headers/default.jpg')}}" />
 	<meta property="og:description" content="{{ config_cache('app.short_description') ?? 'Decentralized photo sharing social media powered by Pixelfed' }}" />
 	<meta name="description" content="{{ config_cache('app.short_description') ?? 'Decentralized photo sharing social media powered by Pixelfed' }}" />
-        <meta name="twitter:title" content="{{ config_cache('app.og_title') }}" />
+        <meta name="twitter:title" content="{{ config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}" />
     <meta name="twitter:description" content="{{ config_cache('app.short_description') ?? 'Decentralized photo sharing social media powered by Pixelfed' }}" />
     <meta name="twitter:image" content="{{ config_cache('app.banner_image') ?? url('storage/headers/default.jpg')}}" />
     <meta name="twitter:card" content="summary_large_image" />

--- a/resources/views/status/embed-removed.blade.php
+++ b/resources/views/status/embed-removed.blade.php
@@ -9,8 +9,8 @@
 
 	<title>Pixelfed | 404 Embed Not Found</title>
 
-	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+	<meta property="og:site_name" content="{{ config_cache('app.name', 'P1000') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
 	<meta name="medium" content="image">
 	<meta name="theme-color" content="#10c5f8">
 	<meta name="apple-mobile-web-app-capable" content="yes">

--- a/resources/views/status/embed-removed.blade.php
+++ b/resources/views/status/embed-removed.blade.php
@@ -10,7 +10,7 @@
 	<title>Pixelfed | 404 Embed Not Found</title>
 
 	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
 	<meta name="medium" content="image">
 	<meta name="theme-color" content="#10c5f8">
 	<meta name="apple-mobile-web-app-capable" content="yes">

--- a/resources/views/status/embed-removed.blade.php
+++ b/resources/views/status/embed-removed.blade.php
@@ -10,7 +10,7 @@
 	<title>Pixelfed | 404 Embed Not Found</title>
 
 	<meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-	<meta property="og:title" content="{{ $title ?? config_cache('app.name', 'pixelfed') }}">
+        <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
 	<meta name="medium" content="image">
 	<meta name="theme-color" content="#10c5f8">
 	<meta name="apple-mobile-web-app-capable" content="yes">

--- a/resources/views/status/embed.blade.php
+++ b/resources/views/status/embed.blade.php
@@ -7,7 +7,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <title>{{ $title ?? config_cache('app.name', 'Pixelfed') }}</title>
     <meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
     <meta property="og:type" content="article">
     <meta property="og:url" content="{{$status['url']}}">
     <meta name="medium" content="image">

--- a/resources/views/status/embed.blade.php
+++ b/resources/views/status/embed.blade.php
@@ -5,9 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="mobile-web-app-capable" content="yes">
-    <title>{{ $title ?? config_cache('app.name', 'Pixelfed') }}</title>
-    <meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'Pixelfed')) }}">
+    <title>{{ $title ?? config_cache('app.name', 'P1000') }}</title>
+    <meta property="og:site_name" content="{{ config_cache('app.name', 'P1000') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title', config_cache('app.name', 'P1000')) }}">
     <meta property="og:type" content="article">
     <meta property="og:url" content="{{$status['url']}}">
     <meta name="medium" content="image">

--- a/resources/views/status/embed.blade.php
+++ b/resources/views/status/embed.blade.php
@@ -7,7 +7,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <title>{{ $title ?? config_cache('app.name', 'Pixelfed') }}</title>
     <meta property="og:site_name" content="{{ config_cache('app.name', 'pixelfed') }}">
-    <meta property="og:title" content="{{ $title ?? config_cache('app.name', 'pixelfed') }}">
+    <meta property="og:title" content="{{ $title ?? config_cache('app.og_title') }}">
     <meta property="og:type" content="article">
     <meta property="og:url" content="{{$status['url']}}">
     <meta name="medium" content="image">


### PR DESCRIPTION
## Summary
- remove the unused APP_OG_TITLE environment/config entries
- switch cached configuration back to the existing app.name key
- update the Open Graph and Twitter meta tags to pull their titles from APP_NAME

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e3e0eb84832ca22c9d1d711186bb